### PR TITLE
update README added missing ':' for inverse_of

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Our Page class above has a method called template. This returns a PageTemplate c
 
 ```
 class PageTemplate < ContentfulModel::Base
-    belongs_to_many :pages, inverse_of :template
+    belongs_to_many :pages, inverse_of: :template
 end
 ```
 


### PR DESCRIPTION
belongs_to_many example has inverse_of, missing the semi-colon