### PR TITLE
🚩 Add method for `include` API parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,13 @@ You'll see from the example above that it accepts an array of search terms which
 ### `locale([string])`
 Fetches the entries for a specific locale code, or all if `'*'` is sent.
 
+### `load_children([integer])`
+Fetches nested links to the specified level.
+
+```
+Foo.load_children(3).load
+```
+
 ## Associations
 You can specify associations between models in a similar way to ActiveRecord. There are some differences, though, so read on.
 

--- a/lib/contentful_model/chainable_queries.rb
+++ b/lib/contentful_model/chainable_queries.rb
@@ -31,6 +31,11 @@ module ContentfulModel
         @query << {'locale' => locale_code}
         self
       end
+      
+      def load_children(n)
+        @query << {'include' => n}
+        self
+      end
 
       def order(args)
         prefix = ''

--- a/spec/chainable_queries_spec.rb
+++ b/spec/chainable_queries_spec.rb
@@ -65,6 +65,11 @@ describe ContentfulModel::ChainableQueries do
       expect(subject.query.parameters).to include('locale' => 'en-US')
     end
 
+    it '::load_children' do
+      expect(subject.load_children(4)).to eq subject
+      expect(subject.query.parameters).to include('include' => 4)
+    end
+
     describe '::order' do
       describe 'when parameter is a hash' do
         it 'ascending' do


### PR DESCRIPTION
Add method for the `include` API parameter, which specifies the number of levels to fetch linked items for. [API documentation](https://www.contentful.com/developers/docs/references/content-delivery-api/#/reference/links/retrieval-of-linked-items/query-entries)

The method couldn't be called `include` because it collided with another object's method name.