### PR TITLE
🚩 Allow arbitrary queries against the Contentful API

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,13 @@ Foo.find_by(someField: [searchquery1, searchquery2], someOtherField: "bar").load
 
 You'll see from the example above that it accepts an array of search terms which will invoke an 'in' query.
 
+### `params({object})`
+Includes the specified parameters in the Contentful API call.
+
+```
+Foo.all.params({"include" => 3}).load
+```
+
 ### `locale([string])`
 Fetches the entries for a specific locale code, or all if `'*'` is sent.
 
@@ -284,7 +291,6 @@ end
 There are quite a few outstanding tasks:
 
 * Some tests :-)
-* Expose the query object to allow an arbitrary query against the Contentful API
 
 # Licence
 MIT - please see MIT-LICENCE in this repo.

--- a/lib/contentful_model/chainable_queries.rb
+++ b/lib/contentful_model/chainable_queries.rb
@@ -12,6 +12,11 @@ module ContentfulModel
         self
       end
 
+      def params(options)
+        @query << options
+        self
+      end
+
       def first
         @query << {'limit' => 1}
         load.first

--- a/spec/chainable_queries_spec.rb
+++ b/spec/chainable_queries_spec.rb
@@ -39,6 +39,11 @@ describe ContentfulModel::ChainableQueries do
       end
     end
 
+    it '::params' do
+      expect(subject.params({'include' => 1})).to eq subject
+      expect(subject.query.parameters).to include('include' => 1)
+    end
+
     it '::first' do
       allow(subject).to receive(:load) { ['first'] }
       expect(subject.first).to eq 'first'


### PR DESCRIPTION
Noticed there was a TODO for this after submitting #38 so thought I'd give it a go 😎

Creates a `params` chainable query method which can be passed an object of parameters to pass to the contentful API call. 