### PR TITLE
Updating .order() to also accept sys properties

### DIFF
--- a/lib/contentful_model/chainable_queries.rb
+++ b/lib/contentful_model/chainable_queries.rb
@@ -53,7 +53,11 @@ module ContentfulModel
         else
           column = args.to_s
         end
-        @query << {'order' => "#{prefix}fields.#{column.camelize(:lower)}"}
+        property_name = column.camelize(:lower).to_sym
+        sys_properties = Contentful::Resource::SystemProperties::SYS_COERCIONS.keys
+        property_type = sys_properties.include?(property_name) ? 'sys' : 'fields'
+
+        @query << {'order' => "#{prefix}#{property_type}.#{property_name}"}
         self
       end
 

--- a/spec/chainable_queries_spec.rb
+++ b/spec/chainable_queries_spec.rb
@@ -97,6 +97,11 @@ describe ContentfulModel::ChainableQueries do
         expect(subject.order('foo')).to eq subject
         expect(subject.query.parameters).to include('order' => 'fields.foo')
       end
+
+      it 'when param is a sys property' do
+        expect(subject.order(:created_at)).to eq subject
+        expect(subject.query.parameters).to include('order' => 'sys.createdAt')
+      end
     end
 
     describe '::find_by' do


### PR DESCRIPTION
According to [Contentful Delivery API docs](https://www.contentful.com/developers/docs/references/content-delivery-api/#/reference/search-parameters/order) we can sort by sys properties as well as field names: 

```
Both the sys properties (such as sys.createdAt) or field values (such as fields.myCustomDateField) can be used for ordering.
```

The current `.order()` method only implements the `order` query hash with "fields".  As a workaround, we're currently the `params(order: '-sys.updatedAt')` to get us where we need to go, but would like to just user the order method as we are elsewhere.

I've updated the `order()` to check the incoming field name against the known keys from `Contentful::Resource::SystemProperties:: SYS_COERCIONS` and use "sys" when matching that key.  I'm not sure if using `SYS_COERCIONS` constant is the best way to go about it, but it got me there.  Open to other suggestions.
