### PR TITLE
has_many, has_one - Preventing further 'AttributeNotFoundError' exception in rescue

### DIFF
--- a/lib/contentful_model/associations/has_many.rb
+++ b/lib/contentful_model/associations/has_many.rb
@@ -34,8 +34,9 @@ module ContentfulModel
             rescue ContentfulModel::AttributeNotFoundError
               # If AttributeNotFoundError is raised, that means that the association name isn't available on the object.
               # We try to call the class name (pluralize) instead, or give up and return an empty collection
-              if options[:class_name].pluralize.underscore.to_sym != association_names
-                self.send(options[:class_name].pluralize.underscore.to_sym)
+              possible_field_name = options[:class_name].pluralize.underscore.to_sym
+              if possible_field_name != association_names && respond_to?(possible_field_name)
+                self.send(possible_field_name)
               else
                 #return an empty collection if the class name was the same as the association name and there's no attribute on the object.
                 []

--- a/lib/contentful_model/associations/has_one.rb
+++ b/lib/contentful_model/associations/has_one.rb
@@ -30,8 +30,9 @@ module ContentfulModel
               super().send(:"#{options[:inverse_of]}=",self)
             rescue ContentfulModel::AttributeNotFoundError
               # If method_missing returns an error, the field doesn't exist. If a class is specified, try that.
-              if options[:class_name].underscore.to_sym != association_name
-                self.send(options[:class_name].underscore.to_sym)
+              possible_field_name = options[:class_name].underscore.to_sym
+              if possible_field_name != association_name && self.respond_to?(possible_field_name)
+                self.send(possible_field_name)
               else
                 #otherwise give up and return nil
                 nil


### PR DESCRIPTION
Currently, the has_one and has_many associations will attempt to fetch the associated fields in this order:
1.  With `super()` - sent to `method_missing` in base.rb and tries to get field.  If can't find, throws AttributeNotFoundError exception (rescued by 2 below)
2.  If rescued from AttributeNotFoundError and the `association_name` != class name, then tries using the class name by doing `.send(options[:class_name].pluralize.underscore.to_sym)`.  This also ends up in `method_missing` and can throw another AttributeNotFoundError exception (not caught because already in rescue block).
3.  If `association_name` == class name, then gives up and returns either nil (for has_one) or [](for has_many)

This causes issues because the Contentful Delivery API simply doesn't include a field at all in the response if that field is left blank for that record in Contentful admin (as said in [README](https://github.com/contentful/contentful_model#returning-nil-for-fields-which-arent-defined)).  If the field isn't included in the response, then no getters are ever set up and AttributeNotFoundError exceptions are thrown in 1 & 2 above.  

I'm suggesting an update to the has_many and has_one to only try last ditch send() on class_name if the object responds to that method.  This prevents further exceptions from being thrown in the rescue block.
