### PR TITLE
Make our version of #cache_key public

### DIFF
--- a/lib/contentful_model/base.rb
+++ b/lib/contentful_model/base.rb
@@ -11,6 +11,14 @@ module ContentfulModel
       self.class.coercions ||= {}
     end
 
+    def cache_key(*timestamp_names)
+      if timestamp_names.present?
+        raise ArgumentError, "ContentfulModel::Base models don't support named timestamps."
+      end
+
+      "#{self.class.to_s.underscore}/#{self.id}-#{self.updated_at.utc.to_s(:usec)}"
+    end
+
     private
 
     def define_getters
@@ -78,14 +86,6 @@ module ContentfulModel
       else
         true
       end
-    end
-
-    def cache_key(*timestamp_names)
-      if timestamp_names.present?
-        raise ArgumentError, "ContentfulModel::Base models don't support named timestamps."
-      end
-
-      "#{self.class.to_s.underscore}/#{self.id}-#{self.updated_at.utc.to_s(:number)}"
     end
 
     class << self

--- a/spec/base_spec.rb
+++ b/spec/base_spec.rb
@@ -36,4 +36,26 @@ describe ContentfulModel::Base do
       }
     end
   end
+
+  describe "#cache_key" do
+    subject(:contentful_object) { MockBase.new('entry_id', space, {'updated_at' => {'en-US' => Time.now}}) }
+
+    it "can be found by #responds_to?" do
+      expect(contentful_object).to respond_to(:cache_key)
+    end
+
+    it "starts with the objects model name" do
+      expect(contentful_object.cache_key).to start_with("mock_base/")
+    end
+
+    it "contains the objects id" do
+      expect(contentful_object.cache_key).to include(contentful_object.id.to_s)
+    end
+
+    it "contains the objects updated timestamp" do
+      expect(contentful_object.cache_key)
+        .to include(contentful_object.updated_at.utc.to_s(:usec))
+    end
+  end
 end
+


### PR DESCRIPTION
This fixes a bug where using our models with Action Views `#cache` wouldn't work as expected – i.e. cache key wouldn't actually include the updated timestamp – using Rails's `[ActiveSupport::Cache::FileStore]` & `watch` was a good way to see this in action.

This is because by default if the object doesn't `#respond_to?(:cache_key)` Rails only calls `#to_s` – assuming it's just a PORO:

```
> ActiveSupport::Cache.expand_cache_key([OpenStruct.new])
=> "#<OpenStruct>"

> ActiveSupport::Cache.expand_cache_key([Struct.new(:to_param).new('ID')])
=> "ID"

> ActiveSupport::Cache.expand_cache_key([Struct.new(:cache_key).new('KEY')])
=> "KEY"

> ActiveSupport::Cache.expand_cache_key([Struct.new(:cache_key) { private(:cache_key, :to_a) }.new('KEY')])
=> "#<struct cache_key=\"KEY\">"
```

For the cache key generation logic see:
https://github.com/rails/rails/blob/3c8f26ac14eb8fc8db45cf5ed020ce1227ce3859/activesupport/lib/active_support/cache.rb#L90
