### PR TITLE
Add note to find_by instructions, use string

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Foo.find("someidfromcontentful")
 ```
 
 ### `find_by([hash])`
-Accepts a hash of options to include in the search, as similar as possible to ActiveRecord version. __Note__ that this doesn't work (and will throw an error) on fields which need the full-text search. This needs fixing. Requires load() to be called at the end of the chain.
+Accepts a hash of options to include in the search, as similar as possible to ActiveRecord version. __Note__ that this doesn't work (and will throw an error) on fields which need the full-text search. This needs fixing. Also the value of the hash has to be a string regardless of the field type in Contentful. Requires load() to be called at the end of the chain.
 
 ```
 Foo.find_by(someField: [searchquery1, searchquery2], someOtherField: "bar").load


### PR DESCRIPTION
When using find_by query, using integer in the query hash value even when the field type in Contentful is integer doesn't work

```
days_in_returned_meals = ContentfulMeal.find_by(day:3).load.map(&:day)
=> [3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 1, 3, 1, 3, 3, 3, 3, 3, 3, 1]
[34] pry(main)> count_of_returned_meals = days_in_returned_meals.count
=> 27
```

Using string returns what I want

```
[35] pry(main)> days_in_returned_meals = ContentfulMeal.find_by(day:"3").load.map(&:day)
=> [3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3]
[36] pry(main)> count_of_returned_meals = days_in_returned_meals.count
=> 24
```

count should be 24
<img width="934" alt="screenshot 2016-10-20 15 33 12" src="https://cloud.githubusercontent.com/assets/3275302/19559944/e35e7a1c-96da-11e6-81ab-cda1fa3181f3.png">

field type for day is integer
<img width="705" alt="screenshot 2016-10-20 15 36 53" src="https://cloud.githubusercontent.com/assets/3275302/19559974/0db98644-96db-11e6-9619-fddfe5e3fd0b.png">
