### PR TITLE
Coerce values that pass through our getters

### DIFF
--- a/lib/contentful_model/base.rb
+++ b/lib/contentful_model/base.rb
@@ -33,9 +33,11 @@ module ContentfulModel
       end
     end
 
-    def define_getter(name)
-      define_singleton_method "#{name.to_s.underscore}" do
-        fields(default_locale)[name]
+    def define_getter(field_name)
+      method_name = field_name.to_s.underscore.to_sym
+
+      define_singleton_method(method_name) do
+        self.class.coerce_value(method_name, fields(default_locale)[field_name])
       end
     end
 
@@ -63,20 +65,7 @@ module ContentfulModel
           raise ContentfulModel::AttributeNotFoundError, "no attribute #{method} found"
         end
       else
-        # if there's no coercion specified, return the result
-        if self.class.coercions[method].nil?
-          return result
-        #if there's a coercion specified for the field and it's a proc, pass the result
-        #to the proc
-        elsif self.class.coercions[method].is_a?(Proc)
-          return self.class.coercions[method].call(result)
-        #provided the coercion is in the COERCIONS constant, call the proc on that
-        elsif !self.class::COERCIONS[self.class.coercions[method]].nil?
-          return self.class::COERCIONS[self.class.coercions[method]].call(result)
-        else
-          #... or just return the result
-          return result
-        end
+        self.class.coerce_value(method, result)
       end
     end
 
@@ -121,6 +110,20 @@ module ContentfulModel
           @coercions.merge!(coercions_hash)
         end
         @coercions
+      end
+
+      def coerce_value(field_name, value)
+        coercion = coercions[field_name]
+
+        if coercion.is_a?(Symbol)
+          coercion = Contentful::Resource::COERCIONS[coercion]
+        end
+
+        if coercion
+          coercion.call(value)
+        else
+          value
+        end
       end
 
       def return_nil_for_empty(*fields)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -26,22 +26,32 @@ class MockSpace
   end
 end
 
-class MockBase < ContentfulModel::Base
-  self.content_type_id = 'ct_id'
+def new_contentful_model
+  klass = Class.new(ContentfulModel::Base) do
+    self.content_type_id = 'ct_id'
 
-  attr_reader :id, :space, :locale
+    attr_reader :id, :space, :locale
 
-  def initialize(id, space, fields = {})
-    @locale = 'en-US'
-    super('fields' => fields)
-    @id = id
-    @space = space
+    def initialize(id, space, fields = {})
+      @locale = 'en-US'
+      super('fields' => fields)
+      @id = id
+      @space = space
+    end
+
+    def fields(locale = default_locale)
+      super || {}
+    end
   end
 
-  def fields(locale = default_locale)
-    super || {}
+  if block_given?
+    klass.class_eval(&Proc.new)
   end
+
+  klass
 end
+
+MockBase = new_contentful_model()
 
 class MockClient
   attr_accessor :response


### PR DESCRIPTION
This puts the use defined coercions between the user and field data at all points in our API – historically we only coercing field values that are accessed via `#method_missing`.