### PR TITLE
Fix for has_many/has_one association(?)

### DIFF
--- a/lib/contentful_model/associations/has_many.rb
+++ b/lib/contentful_model/associations/has_many.rb
@@ -28,8 +28,8 @@ module ContentfulModel
               # this will end up in ContentfulModel::Base#method_missing and return the value from Contentful.
               # We set the singular of the association name on each object in the collection to allow easy
               # reverse recursion without another API call (i.e. finding the Foo which called .bars())
-              super().collect do |child|
-                child.send(:"#{options[:inverse_of]}=",self)
+              super().each do |child|
+                child.send(:"#{options[:inverse_of]}=",self) if child.respond_to?(:"#{options[:inverse_of]}=")
               end
             rescue ContentfulModel::AttributeNotFoundError
               # If AttributeNotFoundError is raised, that means that the association name isn't available on the object.

--- a/lib/contentful_model/associations/has_one.rb
+++ b/lib/contentful_model/associations/has_one.rb
@@ -27,7 +27,9 @@ module ContentfulModel
               # Start by calling the association name as a method on the superclass.
               # this will end up in ContentfulModel::Base#method_missing and return the value from Contentful.
               # We set the singular of the association name on this object to allow easy recursing.
-              super().send(:"#{options[:inverse_of]}=",self)
+              super().tap do |child|
+                child.send(:"#{options[:inverse_of]}=",self) if child.respond_to?(:"#{options[:inverse_of]}=")
+              end
             rescue ContentfulModel::AttributeNotFoundError
               # If method_missing returns an error, the field doesn't exist. If a class is specified, try that.
               possible_field_name = options[:class_name].underscore.to_sym


### PR DESCRIPTION
Might be a little off base here, but I noticed an issue with the has_many & has_one class methods.  Specifically an issue when the associated model does not have an inverse association set up.

Changes for both:
* I don't think it's required to have the inverse association set up on the child model and use the "inverse_of" keyword.  Therefore, I'm adding a check to ensure that the child responds to the inverse setter before attempting.  Previously, even if the call to super() here works, the `child.send()` could throw an AttributeNotFoundError exception and cause this to jump into the rescue.  This method would then return an empty array even though the `super()` correctly returned an array of associated objects.

Other change for has_many:
* I don't _think_ we want this method to return the result of `.collect` as it was doing before.  That would result in an array of whatever the setter returns.  Changed that to `.each`