### PR TITLE
Updating query#execute to call `reject!` on result.items

### DIFF
--- a/lib/contentful_model/query.rb
+++ b/lib/contentful_model/query.rb
@@ -17,7 +17,8 @@ module ContentfulModel
     def execute
       query = @parameters.merge(default_parameters)
       result = client.send(:entries,query)
-      return result.to_a.reject {|entity| entity.is_a?(Contentful::Link) || entity.invalid?}
+      result.items.reject! { |entity| entity.is_a?(Contentful::Link) || entity.invalid? }
+      result
     end
 
     def client


### PR DESCRIPTION
Not sure if this is the best approach, but I noticed that ContentfulModel is returning all results as instance of `Array` instead of `Contentful::Array`.  Because of this, we lose access to some of the pagination methods that come from `Contentful::Array` (`total`, `next_page`, etc).  Looks like that's because of both the `to_a` and `reject` here being called straight on the `result` object.

My recommendation here is to simply call the `reject!` on the items within the results.  This will allow `execute` to return a Contentful::Array.  I think this is a small step in the right direction, however there are still problems with this code.  Mainly that if items are rejected, the `result.total` will no reflect the lose of the item(s).  Though that value is coming straight from the API.  So until there is a way to request only "valid" resources from the Delivery API, then I don't think we'll be able to do a `.reject` _and_ have an accurate `result.total`.  So maybe that should just be a known issue?  Lemme know what you think.