### PR TITLE
Potential fix for PresenceValidation

### DIFF
--- a/lib/contentful_model/base.rb
+++ b/lib/contentful_model/base.rb
@@ -47,7 +47,7 @@ module ContentfulModel
       # we need to pull out any Contentful::Link references, and also things which don't have any fields at all
       # because they're newly created
       if result.is_a?(Array)
-        result.reject! {|r| r.is_a?(Contentful::Link) || (r.respond_to?(:invalid) && r.invalid?)}
+        result.reject! { |r| r.is_a?(Contentful::Link) || (r.respond_to?(:invalid?) && r.invalid?) }
       elsif result.is_a?(Contentful::Link)
         result = nil
       elsif result.respond_to?(:fields) && result.send(:fields).empty?

--- a/lib/contentful_model/validations/validates_presence_of.rb
+++ b/lib/contentful_model/validations/validates_presence_of.rb
@@ -24,7 +24,7 @@ module Contentful
         errors = []
 
         fields.each do |field|
-          errors << "#{field} is required" unless entry.respond_to?(field) && (entry.try(field) rescue nil).present?
+          errors << "#{field} is required" unless entry.respond_to?(field) && (entry.send(field) rescue nil).present?
         end
 
         errors

--- a/lib/contentful_model/validations/validates_presence_of.rb
+++ b/lib/contentful_model/validations/validates_presence_of.rb
@@ -24,7 +24,7 @@ module Contentful
         errors = []
 
         fields.each do |field|
-          errors << "#{field} is required" unless entry.respond_to?(field) && entry.try(field).present?
+          errors << "#{field} is required" unless entry.respond_to?(field) && (entry.try(field) rescue nil).present?
         end
 
         errors

--- a/lib/contentful_model/validations/validates_presence_of.rb
+++ b/lib/contentful_model/validations/validates_presence_of.rb
@@ -24,7 +24,7 @@ module Contentful
         errors = []
 
         fields.each do |field|
-          errors << "#{field} is required" unless entry.respond_to?(field)
+          errors << "#{field} is required" unless entry.respond_to?(field) && entry.try(field).present?
         end
 
         errors


### PR DESCRIPTION
This validator currently only checks if the instance can `respond_to?` the noted field, which is always true if you have declared the field as a has_one, has_many, or return_nil_for_empty.

* Updating validates_presence_of to check `.present?` in addition to `respond_to?`
* Had to rescue the `.send(field)` as it could return `ContentfulModel::AttributeNotFoundError` even if declared in has_one, has_many, or return_nil_for_empty.
* Also fixing issue with crucial `method_missing`, where it attempts to filter out "invalid" entries from being returned.  The `reject` condition was running against `respond_to?(:invalid)` but should be checking `respond_to?(:invalid)`