### PR TITLE
require_all 2.0 is not compatible anymore

### DIFF
--- a/contentful_model.gemspec
+++ b/contentful_model.gemspec
@@ -23,6 +23,9 @@ Gem::Specification.new do |s|
 
   s.add_dependency "redcarpet"
   s.add_dependency "activesupport"
+  
+  # require_all 2.0 isn't compatible anymore, due to 
+  # https://github.com/jarmo/require_all/pull/21
   s.add_dependency 'require_all', '~> 1'
 
   s.add_development_dependency "vcr"

--- a/contentful_model.gemspec
+++ b/contentful_model.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "redcarpet"
   s.add_dependency "activesupport"
-  s.add_dependency 'require_all'
+  s.add_dependency 'require_all', '~> 1'
 
   s.add_development_dependency "vcr"
   s.add_development_dependency "rspec"


### PR DESCRIPTION
The breaking change was https://github.com/jarmo/require_all/pull/21

I think ideally contentful_model should remove the require_all dependency.