### PR TITLE
Correct coercion type and add a link to list

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,10 +49,11 @@ ContentfulModel takes care of setting instance variables for each field in your 
 class Foo < ContentfulModel::Base
    self.content_type_id = "content type id for this model"
 
-   coerce_field birthday: :date
-   coerce_field store_id: :integer
+   coerce_field birthday: :Date
+   coerce_field store_id: :Integer
 end
 ```
+See a list of the available coercions [here](https://github.com/contentful/contentful.rb/blob/master/lib/contentful/field.rb#L9-L22).
 
 ## Queries and Searching
 ContentfulModel allows you to chain queries, like ActiveRecord. The options are as follows.


### PR DESCRIPTION
The coercions to `Date` and `Integer` are documented wrongly in the README. This PR corrects that & adds a link to all the available coercions.