### PR TITLE
Add support for rich_text field

### DIFF
--- a/lib/contentful_model/migrations/content_type.rb
+++ b/lib/contentful_model/migrations/content_type.rb
@@ -6,6 +6,11 @@ module ContentfulModel
     class ContentType
       attr_accessor :id, :name
 
+      MANAGEMENT_TYPE_MAPPING = {
+        'string' => 'Symbol',
+        'rich_text' => 'RichText'
+      }.freeze
+
       def initialize(name = nil, management_content_type = nil)
         @name = name
         @management_content_type = management_content_type
@@ -78,12 +83,12 @@ module ContentfulModel
       def management_type(type)
         if %i[text symbol integer number date boolean location object].include?(type.to_sym)
           type.capitalize
-        elsif type == 'string'
-          'Symbol'
         elsif link?(type)
           'Link'
         elsif array?(type)
           'Array'
+        elsif MANAGEMENT_TYPE_MAPPING.key?(type.to_s)
+          MANAGEMENT_TYPE_MAPPING[type.to_s]
         else
           raise_field_type_error(type)
         end

--- a/spec/migrations/content_type_spec.rb
+++ b/spec/migrations/content_type_spec.rb
@@ -127,6 +127,12 @@ describe ContentfulModel::Migrations::ContentType do
         expect(items.link_type).to eq('Asset')
       end
 
+      it 'rich_text field' do
+        field = subject.field('foo', :rich_text)
+
+        expect(field.type).to eq('RichText')
+      end
+
       it 'fails on unknown type' do
         expect { subject.field('foo', :bar) }.to raise_error ContentfulModel::Migrations::InvalidFieldTypeError
       end


### PR DESCRIPTION
Currently, there is no way to define a rich_text field via migration.
This PR adds support for that
```ruby
class CreateFooContentType < ActiveRecord::Migration
  include ContentfulModel::Migrations::Migration

  def up
    create_content_type('foo') do |ct|
      ct.field('bar', :rich_text)
    end
  end

  def down
  end
end
```