### PR TITLE
Allow to specify display field during migration

### DIFF
--- a/lib/contentful_model/migrations/content_type.rb
+++ b/lib/contentful_model/migrations/content_type.rb
@@ -4,7 +4,7 @@ module ContentfulModel
   module Migrations
     # Class for defining Content Type transformations
     class ContentType
-      attr_accessor :id, :name
+      attr_accessor :id, :name, :display_field
 
       def initialize(name = nil, management_content_type = nil)
         @name = name
@@ -19,10 +19,12 @@ module ContentfulModel
           ).create(
             id: id || camel_case(@name),
             name: @name,
+            displayField: display_field,
             fields: fields
           )
         else
           @management_content_type.fields = @fields
+          @management_content_type.displayField = display_field if display_field
           @management_content_type.save
         end
 


### PR DESCRIPTION
Currently, there is no way to specify displayField for a content type.
This PR adds that ability
```ruby
create_content_type 'StaticPage' do |ct|
  ct.display_field = 'title'

  ct.field 'title', :string
  ct.field 'slug', :string
end
```