### PR TITLE
Add support for symbol_array type

### DIFF
--- a/lib/contentful_model/migrations/content_type.rb
+++ b/lib/contentful_model/migrations/content_type.rb
@@ -103,10 +103,16 @@ module ContentfulModel
       end
 
       def management_items(type)
-        if %i[entry_array asset_array].include?(type.to_sym)
+        if %i[entry_array asset_array symbol_array].include?(type.to_sym)
+          array_type = type.split('_').first.capitalize
+
           items = Contentful::Management::Field.new
-          items.type = 'Link'
-          items.link_type = type.split('_').first.capitalize
+          if %i[entry_array asset_array].include?(type.to_sym)
+            items.type = 'Link'
+            items.link_type = array_type
+          else
+            items.type = array_type
+          end
 
           items
         else

--- a/spec/migrations/content_type_spec.rb
+++ b/spec/migrations/content_type_spec.rb
@@ -158,6 +158,21 @@ describe ContentfulModel::Migrations::ContentType do
         expect(items.link_type).to eq('Asset')
       end
 
+      it 'symbol array field' do
+        field = subject.field('foo', :symbol_array)
+
+        expect(field.id).to eq('foo')
+        expect(field.name).to eq('foo')
+        expect(field.type).to eq('Array')
+        expect(field.link_type).to eq(nil)
+
+        items = field.items
+
+        expect(items).to be_a(Contentful::Management::Field)
+        expect(items.type).to eq('Symbol')
+        expect(items.link_type).to eq(nil)
+      end
+
       it 'rich_text field' do
         field = subject.field('foo', :rich_text)
 


### PR DESCRIPTION
Currently, `contenful_model` migrations API allows only `entry_array` and `asset_array` types.
This PR adds support for `symbol_array` - basically a list of symbol items