### PR TITLE
Fix loss of configured default_locale

### DIFF
--- a/lib/contentful_model.rb
+++ b/lib/contentful_model.rb
@@ -35,6 +35,8 @@ module ContentfulModel
     def initialize
       @entry_mapping ||= {}
       @environment = 'master'
+      @integration_name = 'contentful_model'
+      @integration_version = ::ContentfulModel::VERSION
     end
 
     # Rather than listing out all the possible attributes as setters, we have a catchall

--- a/lib/contentful_model/manageable.rb
+++ b/lib/contentful_model/manageable.rb
@@ -79,9 +79,7 @@ module ContentfulModel
     private
 
     def management_proxy
-      @management_proxy ||= self.class.management(
-        default_locale: locale
-      ).entries(
+      @management_proxy ||= self.class.management.entries(
         space.id,
         ContentfulModel.configuration.environment
       )
@@ -133,12 +131,7 @@ module ContentfulModel
     module ClassMethods
       def management(options = {})
         @management ||= ContentfulModel::Management.new(
-          options.merge(
-            default_locale: ContentfulModel.configuration.default_locale,
-            raise_errors: true,
-            integration_name: 'contentful_model',
-            integration_version: ::ContentfulModel::VERSION
-          )
+          options.merge(raise_errors: true)
         )
       end
 

--- a/lib/contentful_model/management.rb
+++ b/lib/contentful_model/management.rb
@@ -2,6 +2,8 @@ module ContentfulModel
   # Wrapper for the CMA Client
   class Management < Contentful::Management::Client
     def initialize(options = {})
+      options = ContentfulModel.configuration.to_hash.merge!(options)
+
       super(ContentfulModel.configuration.management_token, options)
     end
   end


### PR DESCRIPTION
Some of the configuration values are being lost because `ContentfulModel::Management` is created without the configured values in some locations. `ContentfulModel::Migrations::ContentTypeFactory.find`, for example, creates an instance of `ContentfulModel::Management` with no configuration.

This change centralises the configuration into `ContentfulModel::Management.initialize` so that all instances use the configured values, such as `default_locale`.

Losing `default_locale` causes errors when a space is configured without the default `en-US` locale.