### PR TITLE
Refresh fields after #remove_field call

### DIFF
--- a/lib/contentful_model/migrations/content_type.rb
+++ b/lib/contentful_model/migrations/content_type.rb
@@ -61,8 +61,8 @@ module ContentfulModel
       end
 
       def remove_field(field_id)
-        fields.reject! { |other| other.id == field_id }
         @management_content_type.fields.destroy(field_id)
+        @fields = fields_from_management_type
       end
 
       def new?

--- a/spec/migrations/content_type_spec.rb
+++ b/spec/migrations/content_type_spec.rb
@@ -81,20 +81,23 @@ describe ContentfulModel::Migrations::ContentType do
 
     it '#remove_field and update fields' do
       mock_ct = Object.new
-      remaining_field = Contentful::Management::Field.new
-      mock_fields = [
+      fields = [
         Contentful::Management::Field.new.tap { |f| f.id = 'foo' },
-        remaining_field
+        Contentful::Management::Field.new.tap { |f| f.id = 'bar' },
       ]
+      fields_from_management_type = [
+        Contentful::Management::Field.new.tap { |f| f.id = 'foo' }
+      ]
+      allow(mock_ct).to receive(:fields) { fields }
       allow(mock_ct).to receive(:id) { 'foo' }
-      allow(mock_ct).to receive(:fields) { mock_fields }
 
-      expect(mock_fields).to receive(:destroy).with('foo')
+      expect(fields).to receive(:destroy).with('foo')
 
       subject = described_class.new(nil, mock_ct)
+      allow(subject).to receive(:fields_from_management_type) { fields_from_management_type }
       subject.remove_field('foo')
 
-      expect(subject.fields).to contain_exactly(remaining_field)
+      expect(subject.fields).to eql fields_from_management_type
     end
 
     describe '#id' do


### PR DESCRIPTION
This is a follow-up PR for this one https://github.com/contentful/contentful_model/pull/133
Unfortunately, there are still issues with the `#remove_field` method.

`#remove_field` calls `@management_content_type.fields.destroy(field_id)` under the hood, that in turn [calls `update(fields: fields)`. ](https://github.com/contentful/contentful-management.rb/blob/master/lib/contentful/management/content_type.rb#L118)
But `fields` is set here https://github.com/contentful/contentful_model/blob/master/lib/contentful_model/migrations/content_type.rb#L31, but at the same time it gets modified here https://github.com/contentful/contentful-management.rb/blob/master/lib/contentful/management/content_type.rb#L159 so, in the end, the `@fields` instanсe variable contains the modified data that incompatible with `#save` call(basically all validation items are hashes and not `Validation` instances)

This PR keeps `Migrations::ContentType#fields` in sync with the `@management_content_type.fields` after `#remove_field` call and makes possible calling `#save` as part of `#remove_content_type_field` call