### PR TITLE
Add load! method

### DIFF
--- a/lib/contentful_model/errors.rb
+++ b/lib/contentful_model/errors.rb
@@ -1,4 +1,5 @@
 module ContentfulModel
   class AssociationError < StandardError; end
   class VersionMismatchError < StandardError; end
+  class NotFoundError < StandardError; end
 end

--- a/lib/contentful_model/queries.rb
+++ b/lib/contentful_model/queries.rb
@@ -22,6 +22,10 @@ module ContentfulModel
         all.load
       end
 
+      def load!
+        all.load!
+      end
+
       def first
         query.first
       end

--- a/lib/contentful_model/query.rb
+++ b/lib/contentful_model/query.rb
@@ -159,6 +159,10 @@ module ContentfulModel
     end
     alias load execute
 
+    def load!
+      load.presence || raise(NotFoundError)
+    end
+
     def client
       @client ||= @referenced_class.client
     end

--- a/spec/query_spec.rb
+++ b/spec/query_spec.rb
@@ -93,6 +93,22 @@ describe ContentfulModel::Query do
       end
     end
 
+    describe '#load!' do
+      it 'raises an error when response is empty' do
+        vcr('query/empty') {
+          expect { subject.load! }.to raise_error ContentfulModel::NotFoundError
+        }
+      end
+
+      it 'returns items when response is not empty' do
+        query = described_class.new(Cat, 'sys.id' => 'nyancat')
+        vcr('nyancat') {
+          entries = query.load!
+          expect(entries.first.id).to eq 'nyancat'
+        }
+      end
+    end
+
     describe '#discover_includes' do
       it 'defaults to 1 for a class without associations' do
         query = described_class.new(Cat)


### PR DESCRIPTION
This PR adds `load!` method that raises an exception(`ContentfulModel::NotFoundError`) when a response is blank(either `nil` or an empty array)
It mirrors Rails bang/non-bang approach