### PR TITLE
Expose `where` query on model base

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,9 @@ Foo.find_by(someField: [searchquery1, searchquery2], someOtherField: "bar").load
 
 You'll see from the example above that it accepts an array of search terms which will invoke an 'in' query.
 
+### `where([hash])`
+An alias for `find_by`.
+
 ### `params({object})`
 Includes the specified parameters in the Contentful API call.
 

--- a/lib/contentful_model/queries.rb
+++ b/lib/contentful_model/queries.rb
@@ -75,6 +75,8 @@ module ContentfulModel
         query.find_by(find_query)
       end
 
+      alias where find_by
+
       def search(parameters)
         query.search(parameters)
       end

--- a/spec/chainable_queries_spec.rb
+++ b/spec/chainable_queries_spec.rb
@@ -145,6 +145,48 @@ describe ContentfulModel::Base do
       end
     end
 
+    describe '::where' do
+      it 'when value is an array' do
+        query = subject.where(foo: [1, 2, 3])
+        expect(query.parameters).to include('fields.foo[in]' => '1,2,3')
+      end
+
+      it 'when value is a string' do
+        query = subject.where(foo: 'bar')
+        expect(query.parameters).to include('fields.foo' => 'bar')
+      end
+
+      it 'when value is a number' do
+        query = subject.where(foo: 1)
+        expect(query.parameters).to include('fields.foo' => 1)
+      end
+
+      it 'when value is a boolean' do
+        query = subject.where(foo: true)
+        expect(query.parameters).to include('fields.foo' => true)
+      end
+
+      it 'when value is a hash' do
+        query = subject.where(foo: {gte: 123})
+        expect(query.parameters).to include('fields.foo[gte]' => 123)
+      end
+
+      it 'when multiple fields' do
+        query = subject.where(foo: true, bar: 123)
+        expect(query.parameters).to include('fields.foo' => true , 'fields.bar' => 123)
+      end
+
+      it 'supports sys fields' do
+        query = subject.where('sys.id': 'foo')
+        expect(query.parameters).to include('sys.id' => 'foo')
+      end
+
+      it 'support sys properties without prefix' do
+        query = subject.where('updatedAt' => 'foo')
+        expect(query.parameters).to include('sys.updatedAt' => 'foo')
+      end
+    end
+
     describe '::paginate' do
       it 'defaults to first page and 100 items and sort by updatedAt' do
         query = subject.paginate


### PR DESCRIPTION
Right now, the `#where` method exists on the `Query` class but not on the base class, meaning you can call `Post.all.where(...)` but not `Post.where(...)`, which is weird. This PR exposes the `where` method on the base class to remove this discrepancy.