### PR TITLE
reverse client configuration asset resource mapping merge

### DIFF
--- a/lib/contentful_model/client.rb
+++ b/lib/contentful_model/client.rb
@@ -6,9 +6,9 @@ module ContentfulModel
     PREVIEW_API_URL = 'preview.contentful.com'.freeze
 
     def initialize(configuration)
-      configuration[:resource_mapping] = configuration.fetch(:resource_mapping, {}).merge(
+      configuration[:resource_mapping] = ({
         'Asset' => ContentfulModel::Asset
-      )
+      }).merge(configuration.fetch(:resource_mapping, {}))
 
       if ContentfulModel.use_preview_api
         configuration[:api_url] = PREVIEW_API_URL


### PR DESCRIPTION
This is to allow manual asset resource mapping as [described here](https://github.com/contentful/contentful.rb#custom-resource-classes).