### PR TITLE
Change contentful-management version constraint

### DIFF
--- a/contentful_model.gemspec
+++ b/contentful_model.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.test_files = Dir['spec/**/*']
 
   s.add_dependency 'contentful', '~> 2.7'
-  s.add_dependency 'contentful-management', '~> 2.0'
+  s.add_dependency 'contentful-management', '~> 3.8'
 
   s.add_dependency 'redcarpet'
   s.add_dependency 'activesupport'


### PR DESCRIPTION
Had some issues with Dependabot updating the `contentful-management` in a really weird way, picking a very old version of this gem to fulfill the version constraints.

I have not tested this at all extensively, but it seems to work.